### PR TITLE
bump gha versions and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily

--- a/.github/workflows/yan.CI.yml
+++ b/.github/workflows/yan.CI.yml
@@ -15,9 +15,9 @@ jobs:
         node-version: [14.x, 16.x, 17.x]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: yarn install


### PR DESCRIPTION
In order to improve our security posture with GitHub Actions usage. I've made a version pinning ether to commit hash or to specific version.
Additionally added `dependabot` to track GHA version changes.
Related issues and policy:
https://github.com/paritytech/ci_cd/issues/114
https://github.com/paritytech/ci_cd/issues/464
https://github.com/paritytech/ci_cd/wiki/Policies-and-regulations:-GitHub-Actions-usage-policies